### PR TITLE
fixing smells in FileParser.java

### DIFF
--- a/hulqREST/src/main/java/com/revature/hulq/util/FileParser.java
+++ b/hulqREST/src/main/java/com/revature/hulq/util/FileParser.java
@@ -86,11 +86,8 @@ public class FileParser {
 			}
 			br.close();
 		} catch (IOException e) {
-			//System.out.println("ERROR: key parser has failed");
 			log.info("ERROR: key parser has failed");
-			//System.out.println("CAUSE: file not found(probably)");
 			log.info("CAUSE: file not found(probably)");
-			//System.out.println("ACTION: obvious");
 			log.info("ACTION: obvious");
 			return null;
 		}
@@ -174,11 +171,8 @@ public class FileParser {
 			}
 			br.close();
 		} catch (IOException e) {
-			//System.out.println("ERROR: key parser has failed");
 			log.info("ERROR: key parser has failed");
-			//System.out.println("CAUSE: file not found(probably)");
 			log.info("CAUSE: file not found(probably)");
-			//System.out.println("ACTION: obvious");
 			log.info("ACTION: obvious");
 			return null;
 		}


### PR DESCRIPTION
There were code smells pertaining to commented out print lines, so I went through and deleted them. 👍 