### PR TITLE
fixed a bug and code smell at the same time in LoggingAspect

### DIFF
--- a/hulqREST/src/main/java/com/revature/hulq/aop/LoggingAspect.java
+++ b/hulqREST/src/main/java/com/revature/hulq/aop/LoggingAspect.java
@@ -51,12 +51,11 @@ public class LoggingAspect
 		for (Class c : excepType) {
 			except.add(c.getSimpleName());
 		}
-		Object obj = new Object();
 		
 		// Surround proceed in try catch
 		try {
 			
-			obj = pjp.proceed();
+			pjp.proceed();
 			
 		} catch (Throwable e) {
 			Error.error("\nin Class:\t"

--- a/hulqREST/src/main/java/com/revature/hulq/aop/LoggingAspect.java
+++ b/hulqREST/src/main/java/com/revature/hulq/aop/LoggingAspect.java
@@ -27,7 +27,7 @@ public class LoggingAspect
 	 *            the pjp
 	 */
 	@Around("everything()")
-	public void traceLogging(ProceedingJoinPoint pjp) {
+	public Object traceLogging(ProceedingJoinPoint pjp) {
 		
 		// Setup for grabbing method information
 		MethodSignature sign = (MethodSignature) pjp.getSignature();
@@ -51,11 +51,12 @@ public class LoggingAspect
 		for (Class c : excepType) {
 			except.add(c.getSimpleName());
 		}
+		Object obj = new Object();
 		
 		// Surround proceed in try catch
 		try {
 			
-			pjp.proceed();
+			obj = pjp.proceed();
 			
 		} catch (Throwable e) {
 			Error.error("\nin Class:\t"
@@ -67,6 +68,7 @@ public class LoggingAspect
 					+ "\nMethod exceptions:\n"
 					+ except, e);
 		}
+		return obj;
 		
 	}
 	


### PR DESCRIPTION
Fixed bug S1854 - which was a useless assignment of a method to the obj variable.
This fix included actually getting ride of the Object obj = new Object() call that was there for no reason, which was codesmell S1481.