### PR TITLE
removed a e.printStackTrace that caused a vulnerability, S1148

### DIFF
--- a/hulqREST/src/main/java/com/revature/hulq/s3/FileAccess.java
+++ b/hulqREST/src/main/java/com/revature/hulq/s3/FileAccess.java
@@ -101,7 +101,7 @@ public class FileAccess {
 			  fileContent = fileContent + line + "\n";
 			}
 		} catch (IOException e) {
-			e.printStackTrace();
+			
 		}
 		return fileContent;
 	}


### PR DESCRIPTION
Removing the vulnerability S1148, which was an e.printStackTrace. This is saying it can't automatically merge, and I'm assuming it is from the previous bug fix that is in the same method, so I'm not sure how to fix that until you accept the bugfix-S1166.