### PR TITLE
Fixed a S1181 bug in LoggingAspect

### DIFF
--- a/hulqREST/src/main/java/com/revature/hulq/aop/LoggingAspect.java
+++ b/hulqREST/src/main/java/com/revature/hulq/aop/LoggingAspect.java
@@ -9,6 +9,8 @@ import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Pointcut;
 import org.aspectj.lang.reflect.MethodSignature;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import com.revature.hulq.util.Error;
@@ -20,6 +22,7 @@ import com.revature.hulq.util.Error;
 @Aspect
 public class LoggingAspect
 {	
+	private final Logger log = LoggerFactory.getLogger(this.getClass());
 	/**
 	 * Trace logging, surrounds the given point cut with error logging.
 	 *
@@ -58,6 +61,8 @@ public class LoggingAspect
 			
 			obj = pjp.proceed();
 			
+		} catch(Exception ex) {
+			log.info("Exception", ex);
 		} catch (Throwable e) {
 			Error.error("\nin Class:\t"
 					+ sign.getDeclaringTypeName()


### PR DESCRIPTION
Was getting a bug in LoggingAspect, cause by a catch block just catching Throwable, so I went in and added a second catch block that catches Exception. I added a logger into the class so that I could log that exception as well. (Sorry it isn't autowired, but I am gonna go back and try to do that when I finish up some of the more pressing things.) 👍 