### PR TITLE
fixed a codesmell in LoggingAspect

### DIFF
--- a/hulqREST/src/main/java/com/revature/hulq/aop/LoggingAspect.java
+++ b/hulqREST/src/main/java/com/revature/hulq/aop/LoggingAspect.java
@@ -77,7 +77,7 @@ public class LoggingAspect
 	 */
 	@Pointcut("execution(* *.hulq.*.*(..))")
 	public void everything() {
-		
+		//This function is empty, as it is used for the pointcut feature for everything
 	}
 	
 }


### PR DESCRIPTION
There was a codesmell(S1186) in this file that was from the empty function for the pointcut. I just went in and added a nested comment to say that. :)