### PR TITLE
fixed a host of bugs in FileParser.java

### DIFF
--- a/hulqREST/src/main/java/com/revature/hulq/util/FileParser.java
+++ b/hulqREST/src/main/java/com/revature/hulq/util/FileParser.java
@@ -15,7 +15,7 @@ public class FileParser {
 	private final Logger log = LoggerFactory.getLogger(this.getClass());
 	public List<String> getArgs(String keyPath) {
 		// string used to hold individual groups of command arguments
-		String valueString = "";
+		StringBuilder valueString = new StringBuilder();
 
 		// List used to hold all groups of command arguments
 		List<String> valueSet = new ArrayList<String>();
@@ -58,10 +58,10 @@ public class FileParser {
 						if (line.contains("%")) {
 							line = line.split("%")[0];
 						}
-						valueString = valueString + " " + line;
+						valueString = valueString.append(" " + line);
 
 						// add value string to value set
-						valueSet.add(valueString.trim());
+						valueSet.add(valueString.toString().trim());
 					}
 
 					// if argument line has comment
@@ -72,19 +72,20 @@ public class FileParser {
 					// parse individual lines of argument notation
 					if (line.startsWith("@ArgSet")) {
 						// if the the argument string is not empty
-						if (valueString != null && !(valueString.equals(""))) {
+						if (valueString != null && !("".equals(valueString))) {
 
-							valueSet.add(valueString.trim());
+							valueSet.add(valueString.toString().trim());
 						}
 						// reset value string
-						valueString = "";
+						valueString.setLength(0);
 					} else if (line.length() != 0) {
 						// add argument line to value string
-						valueString = valueString + " " + line;
+						valueString = valueString.append(" " + line);
 					}
 				}
 			}
 		} catch (IOException e) {
+			log.info("IOException", e);
 			log.info("ERROR: key parser has failed");
 			log.info("CAUSE: file not found(probably)");
 			log.info("ACTION: obvious");
@@ -117,7 +118,7 @@ public class FileParser {
 					break;
 				}
 
-				if (line.equalsIgnoreCase("@Config")) {
+				if ("@Config".equalsIgnoreCase(line)) {
 					inConfigLine = true;
 					continue;
 				}
@@ -132,7 +133,6 @@ public class FileParser {
 					if (val.length == 2) {
 
 						val[0] = val[0].toLowerCase();
-						val[1] = val[1];
 						switch (val[0]) {
 						case "mathmode":
 							testProfile.setMathMode(Boolean.parseBoolean(val[1]));
@@ -169,6 +169,7 @@ public class FileParser {
 				}
 			}
 		} catch (IOException e) {
+			log.info("IOException", e);
 			log.info("ERROR: key parser has failed");
 			log.info("CAUSE: file not found(probably)");
 			log.info("ACTION: obvious");


### PR DESCRIPTION
S1643, use StringBuilder, just went through and converted string to StringBuilder
S1132, move string literal to left of comparison, did exactly that
S1643, use StringBuilder, just went through and converted string to StringBuilder (happened with first one)
S1166, log this exception, went in and logged the exception that could be thrown
S1132, move string literal to left of comparison, did that with the "@Config" string
S1656, remove useless assignment, took the assignment val[1]=val[1] out
S1166, log this exception, went in and logged the exception that could be thrown

👍 