### PR TITLE
bugfix s2259

### DIFF
--- a/AssociateEvaluationSystem/src/main/java/com/revature/aes/service/S3Service.java
+++ b/AssociateEvaluationSystem/src/main/java/com/revature/aes/service/S3Service.java
@@ -69,12 +69,8 @@ public class S3Service {
 
 	public boolean uploadAssReqToS3(AssessmentRequest assessContents, String key){
 		File file2 = null;
-		FileOutputStream file = null;
-		ObjectOutputStream oos = null;
-		try {
+		try (FileOutputStream file = new FileOutputStream(file2); ObjectOutputStream oos = new ObjectOutputStream(file)) {
 			file2 = new File("AssessRequest");
-			file = new FileOutputStream(file2);
-			oos = new ObjectOutputStream(file);
 			oos.writeObject(assessContents);
 			
 
@@ -88,15 +84,6 @@ public class S3Service {
 		{
 			log.error(Logging.errorMsg("uploading Assessment Req to S3", e));
 			return false;
-		}
-		finally {
-			try {
-				oos.close();
-				file.close();
-			} catch (IOException e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
-			}
 		}
 	}
 


### PR DESCRIPTION
Put fileoutputstream and objectoutputstream objects into a try-with-resources statement so that these resources will automatically close after the statement ends, or if an exception occurs and they are not initialized then it will not be necessary to null-check and manually close them in a finally block.

Before this change it was possible for the stream to be null, and were close() to be invoked in that case then an uncaught nullpointerexception would have been thrown.