### PR TITLE
bugfix s1166

### DIFF
--- a/AssociateEvaluationSystem/src/main/java/com/revature/aes/service/S3Service.java
+++ b/AssociateEvaluationSystem/src/main/java/com/revature/aes/service/S3Service.java
@@ -69,12 +69,8 @@ public class S3Service {
 
 	public boolean uploadAssReqToS3(AssessmentRequest assessContents, String key){
 		File file2 = null;
-		FileOutputStream file = null;
-		ObjectOutputStream oos = null;
-		try {
+		try (FileOutputStream file = new FileOutputStream(file2); ObjectOutputStream oos = new ObjectOutputStream(file)) {
 			file2 = new File("AssessRequest");
-			file = new FileOutputStream(file2);
-			oos = new ObjectOutputStream(file);
 			oos.writeObject(assessContents);
 			
 
@@ -88,15 +84,6 @@ public class S3Service {
 		{
 			log.error(Logging.errorMsg("uploading Assessment Req to S3", e));
 			return false;
-		}
-		finally {
-			try {
-				oos.close();
-				file.close();
-			} catch (IOException e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
-			}
 		}
 	}
 


### PR DESCRIPTION
For bugfix-S2259 the uploadAssReqToS3(..) method had been rewritten to use a try-with-resources statement to handle initializing and auto-closing the stream objects. This allowed removing the manual invocation of close() on these objects and also removed the catch statement for the IOException, which makes the original request to log the exception no longer applicable and this bug already addressed.