### PR TITLE
bugfix-jsS1871: merged case statements that returned the same string

### DIFF
--- a/AssociateEvaluationSystem/src/main/resources/static/js/globalSettings.js
+++ b/AssociateEvaluationSystem/src/main/resources/static/js/globalSettings.js
@@ -69,8 +69,7 @@ adminApp.controller("menuCtrl", function($scope, $location, $timeout, $mdSidenav
         var path = window.location.pathname.substr(1);
 
         switch(path) {
-            case "aes/registerEmployee" : return "employees";
-            case "aes/updateEmployee" : return "employees";
+            case "aes/registerEmployee" : case "aes/updateEmployee" : return "employees";
             case "aes/createAssessment" : return "assessments";
             case "aes/globalSettings" : return "globalSettings";
             default : return "overview"


### PR DESCRIPTION
These case statements were separated by a break even though they returned the same string, "employees". By making them fall through it is clearer that they return the same string and simplifies the code.