### PR TITLE
smellfix-js duplicated blocks in globalsettings.js

### DIFF
--- a/AssociateEvaluationSystem/src/main/resources/static/js/globalSettings.js
+++ b/AssociateEvaluationSystem/src/main/resources/static/js/globalSettings.js
@@ -77,18 +77,8 @@ adminApp.controller("menuCtrl", function($scope, $location, $timeout, $mdSidenav
         }
     };
 
-    mc.buildToggler = function(navID) {
-        return function() {
-            $mdSidenav(navID)
-                .toggle()
-                .then(function() {
-                    $log.debug("toggle " + navID + " is done");
-                });
-        };
-    };
-    $scope.isOpenLeft = function() {
-        return $mdSidenav('left').isOpen();
-    };
+    mc.buildToggler = buildToggler;
+    $scope.isOpenLeft = isOpenSideNav('left');
 
 
     // data
@@ -96,22 +86,27 @@ adminApp.controller("menuCtrl", function($scope, $location, $timeout, $mdSidenav
     $scope.toggleLeft = mc.buildToggler('left');
 
  // $scope.toggleLeft = buildDelayedToggler('left');
-    $scope.toggleRight = buildToggler('right');
-    $scope.isOpenRight = function() {
-        return $mdSidenav('right').isOpen();
-    };
+    $scope.toggleRight = mc.buildToggler('right');
+    $scope.isOpenRight = isOpenSideNav('right');
 
-    $scope.toggleAss = buildToggler('ass');
-    $scope.isOpenAss = function(){
-    	return $mdSidenav('ass').isOpen();
-    };
+    $scope.toggleAss = mc.buildToggler('ass');
+    $scope.isOpenAss = isOpenSideNav('ass');
     
     function buildToggler(navID) {
         return function() {
             // Component lookup should always be available since we are not using `ng-if`
             $mdSidenav(navID)
                 .toggle()
+                .then(function() {
+                	$log.debug("toggle " + navID + " is done");
+                });
         };
+    }
+    
+    function isOpenSideNav(sideNav) {
+    	return function() {
+    		$mdSidenav(sideNav).isOpen();
+    	};
     }
 
 });


### PR DESCRIPTION
This code smell was about duplicate code. There was a function that called toggle() of the $mdSidenav object and an inline anonymous function that did the same thing but simply added a call to the $log service. I modified the function to include this call to $log and used this function instead of the inline function.

There were other inline functions that called the isOpen() function of a particular $mdSidenav. I wrote a function that took a string identifying a particular sidenav and assigned this function where the inline function had been used.

These changes remove the duplicate code that was there before while maintaining the same functionality.